### PR TITLE
feat: make equilibrium compatible with Java 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ You can use this annotation processor in **commercial or closed-source projects*
 
 ## Requirements
 
-- **Java 21** or higher (the processor targets the Java 21 language level)
+- **Java 17** or higher (the processor targets the Java 17 language level)
 - A build tool that can **resolve dependencies** from Maven Central (or your repository) and run **annotation processing** (for example Maven 3.x or Gradle 8.x)
 
 Older tool versions may work but are not validated. **Building Project Equilibrium** uses Maven in this repository; consuming projects do not need to run this project’s `pom.xml`.

--- a/docs/troubleshooting-and-pitfalls.md
+++ b/docs/troubleshooting-and-pitfalls.md
@@ -128,7 +128,7 @@ Details: [Annotations reference](annotations-reference.md) (*Selective exclusion
 
 - Equilibrium targets **Java** sources; **Kotlin** / **`kapt`** is **not** supported or tested here.
 - This repo is validated with **Maven**; **Gradle** can work in principle but you must wire the processor path and **`-Aequilibrium.*`** yourself—see [Build tooling](build-tooling.md) (*Installation (Gradle)*).
-- **Java 21+** is required for the language level this processor assumes.
+- **Java 17+** is required for the language level this processor assumes.
 
 ---
 

--- a/docs/why-equilibrium.md
+++ b/docs/why-equilibrium.md
@@ -17,7 +17,7 @@ Project Equilibrium generates those types at compile time from your annotated do
 
 - You have a domain model you annotate once and one or more layers (API, persistence, messaging) that need derived types from it
 - You want fast, predictable builds with plain generated Java sources you can read
-- You are comfortable with annotation-driven configuration and Java 21+
+- You are comfortable with annotation-driven configuration and Java 17+
 
 ## When to reach for something else
 

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.release>21</maven.compiler.release>
+    <maven.compiler.release>17</maven.compiler.release>
     <auto-service.version>1.1.1</auto-service.version>
     <junit-jupiter.version>5.13.1</junit-jupiter.version>
     <compile-testing.version>0.21.0</compile-testing.version>

--- a/src/main/java/io/github/soulcodingmatt/equilibrium/processor/model/CustomObjectDetector.java
+++ b/src/main/java/io/github/soulcodingmatt/equilibrium/processor/model/CustomObjectDetector.java
@@ -116,7 +116,7 @@ public class CustomObjectDetector {
         // Check if it's a known collection type
         if (isCollectionType(qualifiedName)) {
           // Return the first type argument (element type)
-          return declaredType.getTypeArguments().getFirst();
+          return declaredType.getTypeArguments().get(0);
         }
       }
     }

--- a/src/main/java/io/github/soulcodingmatt/equilibrium/processor/orchestration/EquilibriumProcessor.java
+++ b/src/main/java/io/github/soulcodingmatt/equilibrium/processor/orchestration/EquilibriumProcessor.java
@@ -62,7 +62,7 @@ import javax.tools.Diagnostic;
   "jakarta.validation.constraints.PastOrPresent",
   "jakarta.validation.constraints.FutureOrPresent"
 })
-@SupportedSourceVersion(SourceVersion.RELEASE_21)
+@SupportedSourceVersion(SourceVersion.RELEASE_17)
 @SupportedOptions({
   "equilibrium.dto.package",
   "equilibrium.dto.postfix",

--- a/src/test/java/io/github/soulcodingmatt/equilibrium/processor/EquilibriumProcessorTest.java
+++ b/src/test/java/io/github/soulcodingmatt/equilibrium/processor/EquilibriumProcessorTest.java
@@ -158,10 +158,10 @@ class EquilibriumProcessorTest {
     SourceVersion supportedVersion = processor.getSupportedSourceVersion();
     assertNotNull(supportedVersion, "Processor must declare a supported source version");
 
-    // Should support at least Java 21 or latest
+    // Should support at least Java 17 or latest
     assertTrue(
-        supportedVersion.ordinal() >= SourceVersion.RELEASE_21.ordinal(),
-        "Processor should support Java 21 or later");
+        supportedVersion.ordinal() >= SourceVersion.RELEASE_17.ordinal(),
+        "Processor should support Java 17 or later");
   }
 
   @Test
@@ -248,9 +248,9 @@ class EquilibriumProcessorTest {
 
     assertFalse(messager.getNoteMessages().isEmpty(), "banner should emit NOTE diagnostics");
     List<TestMessage> notes = messager.getNoteMessages();
-    assertEquals("", notes.getFirst().getMessage(), "blank line precedes top rule");
+    assertEquals("", notes.get(0).getMessage(), "blank line precedes top rule");
     String topRule = notes.get(1).getMessage();
-    String bottomRule = notes.getLast().getMessage();
+    String bottomRule = notes.get(notes.size() - 1).getMessage();
     assertTrue(topRule.chars().allMatch(ch -> ch == '='));
     assertTrue(bottomRule.chars().allMatch(ch -> ch == '-'));
     assertEquals(topRule.length(), bottomRule.length());
@@ -434,7 +434,7 @@ class EquilibriumProcessorTest {
 
     // Assert
     assertEquals(1, fixtureMessager.getErrorMessages().size());
-    TestMessage errorMessage = fixtureMessager.getErrorMessages().getFirst();
+    TestMessage errorMessage = fixtureMessager.getErrorMessages().get(0);
     assertEquals(Diagnostic.Kind.ERROR, errorMessage.getKind());
     assertEquals("Test error with element", errorMessage.getMessage());
     assertNull(errorMessage.getElement());
@@ -451,8 +451,7 @@ class EquilibriumProcessorTest {
 
     // Assert
     assertEquals(1, fixtureMessager.getGeneralErrorMessages().size());
-    assertEquals(
-        "Test error without element", fixtureMessager.getGeneralErrorMessages().getFirst());
+    assertEquals("Test error without element", fixtureMessager.getGeneralErrorMessages().get(0));
   }
 
   @Test
@@ -475,7 +474,7 @@ class EquilibriumProcessorTest {
 
     // Assert
     assertEquals(1, fixtureMessager.getGeneralErrorMessages().size());
-    String actualMessage = fixtureMessager.getGeneralErrorMessages().getFirst();
+    String actualMessage = fixtureMessager.getGeneralErrorMessages().get(0);
     assertTrue(actualMessage.contains("Failed to process annotations"));
     assertTrue(actualMessage.contains("Test exception message"));
     assertTrue(actualMessage.contains("RuntimeException"));
@@ -493,7 +492,7 @@ class EquilibriumProcessorTest {
 
     // Assert
     assertEquals(1, fixtureMessager.getNoteMessages().size());
-    TestMessage noteMessage = fixtureMessager.getNoteMessages().getFirst();
+    TestMessage noteMessage = fixtureMessager.getNoteMessages().get(0);
     assertEquals(Diagnostic.Kind.NOTE, noteMessage.getKind());
     assertEquals("Test note message", noteMessage.getMessage());
   }
@@ -800,7 +799,7 @@ class EquilibriumProcessorTest {
     assertTrue(
         fixtureMessager
             .getErrorMessages()
-            .getFirst()
+            .get(0)
             .getMessage()
             .contains("can only be applied to classes"),
         "Error message should indicate annotations can only be applied to classes");
@@ -825,7 +824,7 @@ class EquilibriumProcessorTest {
     assertTrue(
         fixtureMessager
             .getErrorMessages()
-            .getFirst()
+            .get(0)
             .getMessage()
             .contains("can only be applied to classes"),
         "Error message should indicate annotations can only be applied to classes");
@@ -1117,7 +1116,7 @@ class EquilibriumProcessorTest {
 
     @Override
     public SourceVersion getSourceVersion() {
-      return SourceVersion.RELEASE_21;
+      return SourceVersion.RELEASE_17;
     }
 
     @Override
@@ -1195,7 +1194,7 @@ class EquilibriumProcessorTest {
 
     @Override
     public SourceVersion getSourceVersion() {
-      return SourceVersion.RELEASE_21;
+      return SourceVersion.RELEASE_17;
     }
 
     @Override


### PR DESCRIPTION
## Summary

- Lower `maven.compiler.release` from 21 to 17 in `pom.xml`
- Replace `SourceVersion.RELEASE_21` with `RELEASE_17` in `EquilibriumProcessor.java`
- Replace `List.getFirst()`/`List.getLast()` (Java 21 SequencedCollection API) with `get(0)`/`get(size-1)` in `CustomObjectDetector.java` and `EquilibriumProcessorTest.java`
- Update documentation (README, why-equilibrium, troubleshooting) to state Java 17+ minimum

Decision basis: ADR-001 — codebase scan found zero Java 21-exclusive language features. All features used (records, pattern matching, switch expressions, text blocks) are Java 17 compatible.

Closes #20, closes #29, closes #30

## Test plan

- [ ] `mvn clean verify` passes with `release=17`
- [ ] All 140+ existing tests pass
- [ ] No Java 21-only API calls remain (`grep -r "getFirst\|getLast\|RELEASE_21" src/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)