### PR TITLE
chore: bump version to 1.1.0-SNAPSHOT, refs #43

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>io.github.soulcodingmatt</groupId>
   <artifactId>equilibrium</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>1.1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Project Equilibrium</name>


### PR DESCRIPTION
## Summary

- Bumps `pom.xml` version from `1.0.0-SNAPSHOT` to `1.1.0-SNAPSHOT`
- Post-release snapshot for next development cycle (Java 17 compat = minor bump)

## Test plan

- [x] Single-line version change in pom.xml

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #43