### PR TITLE
docs: document minimum Lombok version for builders, refs #45

### DIFF
--- a/docs/dto-builder-pattern.md
+++ b/docs/dto-builder-pattern.md
@@ -5,7 +5,7 @@ Use this when you want **Lombok’s builder** on generated DTOs. Project Equilib
 ## Prerequisites
 
 - **`@GenerateDto(builder = true)`** on your domain (or API) class.
-- **Lombok** on your classpath and on the **annotation processor path** (see the main README). Project Equilibrium does not replace Lombok; it generates code that Lombok then expands.
+- **Lombok 1.18.2 or higher** on your classpath and on the **annotation processor path** (see the main README). Project Equilibrium does not replace Lombok; it generates code that Lombok then expands. Version 1.18.2 is the minimum because `@SuperBuilder` was introduced in that release.
 
 If you do not need builders, omit `builder` and use constructors and setters instead.
 

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -17,6 +17,14 @@ Use [MapStruct](https://mapstruct.org/) `@Mapper` interfaces to map between doma
 
 Different modules can standardize on different pieces: for example, generated DTOs in an API module and MapStruct mappers in an adapter layer.
 
+## Lombok version compatibility
+
+Project Equilibrium has **no runtime dependency** on Lombok. When you enable `@GenerateDto(builder = true)`, the processor emits `@SuperBuilder` and `@Builder.Default` annotations into generated source code. Your project's Lombok then expands these during its own annotation processing pass.
+
+- **Minimum Lombok version for builders:** **1.18.2** (`@SuperBuilder` was introduced in this release)
+- **No maximum version constraint** — Equilibrium emits standard Lombok annotations as string literals, so any newer Lombok version that supports `@SuperBuilder` will work
+- **Without builders:** Lombok is entirely optional; Equilibrium has no Lombok dependency
+
 ## Related guides
 
 - [DTO builder pattern](dto-builder-pattern.md) when using Lombok `@SuperBuilder` on generated DTOs


### PR DESCRIPTION
## Summary

- Added minimum Lombok version (1.18.2+) to `docs/dto-builder-pattern.md` prerequisites
- Added Lombok version compatibility section to `docs/ecosystem.md` explaining the relationship

## Test plan

- [x] Documentation-only change, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #45